### PR TITLE
Give 443 egress for container fetching, etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,41 @@ design decisions.
 
 ## Usage Example
 
-TODO
+```
+module "kubeinfra" {
+  source = "github.com/ausmith/terraform-aws-kubernetes-infra"
+
+  vpc_cidr           = "${var.vpc_cidr}"
+  name               = "prototype"
+  region             = "us-west-2"
+  owner_tag          = "me"
+  env_tag            = "prod"
+  toggle_ingress_nlb = 0
+
+  # This is ugly enumerating out each AZ, templating perhaps?
+  az_list = [
+    "us-west-2a",
+    "us-west-2b",
+  ]
+
+  # Will need to template these CIDRs somehow
+  public_subnet_cidrs = [
+    "172.20.0.0/24",
+    "172.20.1.0/24",
+  ]
+
+  private_subnet_cidrs = [
+    "172.20.10.0/24",
+    "172.20.11.0/24",
+  ]
+
+  ingress_ports = []
+
+  control_origins = [
+    "${var.my_public_ip_cidr}",
+  ]
+}
+```
 
 ## Suggested Additions
 

--- a/kube_master_sg.tf
+++ b/kube_master_sg.tf
@@ -159,6 +159,21 @@ resource "aws_security_group_rule" "kube_master_to_localhost_and_kube" {
 }
 */
 
+resource "aws_security_group_rule" "kube_master_https_to_internet" {
+  # Alas, without this we cannot fetch docker containers
+  type        = "egress"
+  from_port   = 443
+  to_port     = 443
+  protocol    = "tcp"
+  description = "HTTPS to the internet"
+
+  cidr_blocks = [
+    "0.0.0.0/0",
+  ]
+
+  security_group_id = "${aws_security_group.kube_master_sg.id}"
+}
+
 resource "aws_security_group_rule" "kube_master_master_kubelet_egress" {
   type                     = "egress"
   from_port                = 10250

--- a/kube_node_sg.tf
+++ b/kube_node_sg.tf
@@ -88,6 +88,21 @@ resource "aws_security_group_rule" "kube_nodes_to_masters_https_egress" {
   description              = "node-master API 443"
 }
 
+resource "aws_security_group_rule" "kube_nodes_https_to_internet" {
+  # Alas, without this we cannot fetch docker containers
+  type        = "egress"
+  from_port   = 443
+  to_port     = 443
+  protocol    = "tcp"
+  description = "HTTPS to the internet"
+
+  cidr_blocks = [
+    "0.0.0.0/0",
+  ]
+
+  security_group_id = "${aws_security_group.kube_node_sg.id}"
+}
+
 resource "aws_security_group_rule" "kube_node_to_master_vxlan_canal_egress" {
   type                     = "egress"
   from_port                = 8472


### PR DESCRIPTION
Some environments may wish for a proxy to be between the nodes and the
outside world. Unfortunately, we cannot generally make that assumption
and that requires work outside the scope of this open source project.
Instead, you must implement that yourself (and perhaps we should add a
toggle for turning off the 443 egress rules).